### PR TITLE
Add listener for onClosedModal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const App = () => {
 | closeButtonText | String | Text for the modal close button
 | closeButtonComponent | Component | Component for the modal close button (i.e : Svg Icon, Image...)
 | onSelectedOption | Function | Callback that will receive the option value defined in the option definition object. Will be called when user selects one of the rows.
+| onClosedModal | Function | Callback that will be called if the user closes the modal without a selection.
 | disableTextSearch | Boolean | If must not display the header text input
 | options[***](#options-object-format) | Array[Object] | Options is an array with static objects to be displayed in the list. Each option object must have a label (to display in the list), and a value which will be returned to the parent component on selection.
 | provider | Function | Provider is a custom function that can be used to fetch any async data. The function can return a promise. The returned value from that function must be in the same format as the options array above.
@@ -66,7 +67,7 @@ When provider function is not defined and the component prefers to use the stati
 | Name | Description |
 | ---- | ----------- |
 | show | Shows the select list and wait until the onSelectedOption callback is called to close it.
-| dismiss | Manually dismiss the select list.
+| dismiss | Manually dismiss the select list and wait until the onClosedModal callback is called (if provided) to close it.
 
 # Examples
 See the ```examples/RNModalSelectListPlayground``` app and play with it.

--- a/src/components/ModalSelectList.js
+++ b/src/components/ModalSelectList.js
@@ -33,10 +33,11 @@ class ModalSelectList extends PureComponent {
 
   handleModalCloseRequest() {
     const { onClosedModal } = this.props;
-    if (onClosedModal) {
-      onClosedModal();
-    }
-    return this.dismiss();
+    this.dismiss(() => {
+      if (typeof onClosedModal === 'function') {
+        onClosedModal();
+      }
+    });
   }
 
   handleRowSelection(value) {

--- a/src/components/ModalSelectList.js
+++ b/src/components/ModalSelectList.js
@@ -32,6 +32,10 @@ class ModalSelectList extends PureComponent {
   }
 
   handleModalCloseRequest() {
+    const { onClosedModal } = this.props;
+    if (onClosedModal) {
+      onClosedModal();
+    }
     return this.dismiss();
   }
 
@@ -72,6 +76,7 @@ ModalSelectList.defaultProps = {
 ModalSelectList.propTypes = {
   ...optionsPropTypes,
   onSelectedOption: PropTypes.func,
+  onClosedModal: PropTypes.func,
 };
 
 export default ModalSelectList;


### PR DESCRIPTION
Adds an optional handler so code calling this component can be aware if the user closes the modal without making a selection. Can be used if "cancel" leads to a special use case on the calling side besides just closing the modal.